### PR TITLE
Removed obsolete 'new's.

### DIFF
--- a/safe-printf.hh
+++ b/safe-printf.hh
@@ -154,7 +154,7 @@ namespace safe_printf
     constexpr bool
     checkFormat(constExprStr str)
     {
-      return str.empty() ? throw new std::logic_error("too many arguments")
+      return str.empty() ? throw std::logic_error("too many arguments")
 	: (str.first() == '%'
 	   ? checkFormatPercent<Arg>(str.tail())
 	   : checkFormat<Arg>(str.tail()));
@@ -165,7 +165,7 @@ namespace safe_printf
     constexpr bool
     checkFormat(constExprStr str)
     {
-      return str.empty() ? throw new std::logic_error("too many arguments")
+      return str.empty() ? throw std::logic_error("too many arguments")
 	: (str.first() == '%'
 	   ? checkFormatPercent<Arg, Arg2, Args...>(str.tail())
 	   : checkFormat<Arg, Arg2, Args...>(str.tail()));


### PR DESCRIPTION
Hi. I was looking for a type-safe `printf` wrapper and found your project. It looks really nice, I like it. :)
I had only a brief look and I haven't tested it but I guess you can strip these two `new`s, can't you?